### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fontra User Docs
 
-[web preview](https://gferreira.github.io/fontra-docs/)
+[web preview](https://docs.fontra.xyz/)
 
 
 
@@ -25,3 +25,7 @@
 5. open the server adress you find in the terminal output, similar to:
 
     `>    Server address: http://127.0.0.1:4000/`
+
+
+# Credits
+[Gustavo Ferreira](https://github.com/gferreira) initiated this documentation

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 title: Fontra Docs
-email: gustavo@hipertipo.com
+email: hello@black-foundry.com
 description: Fontra user documentation
 baseurl: ""
-url: https://gferreira.github.io/fontra-docs
+url: https://googlefonts.github.io/fontra-docs
 
 collections:
   explanations:

--- a/_explanations/documentation.md
+++ b/_explanations/documentation.md
@@ -45,7 +45,7 @@ order     : 2
 - additional styles are written in [Sass] (for example custom font, custom classes, icon, etc.)
 - the website is updated automatically at every commit to the `main` branch of the repository
 
-[fontra-docs]: http://github.com/gferreira/fontra-docs
+[fontra-docs]: http://github.com/googlefonts/fontra-docs
 [Jekyll]: http://jekyllrb.com/
 [GitHub Pages]: http://pages.github.com/
 [kramdown]: http://kramdown.gettalong.org/index.html
@@ -59,7 +59,7 @@ order     : 2
 if you see a mistake or would like to propose an improvement:
 
 - create an issue on the `fontra-docs` repository
-- send a message on [Discord](#) with the label `docs`
+- send a message on [Discord](https://discord.gg/SeZWugEYzd) with the label `docs`
 - fork the `fontra-docs` repository and submit a pull request
 {% endcomment %}
 

--- a/css/style.sass
+++ b/css/style.sass
@@ -30,8 +30,7 @@ main, footer
     text-decoration: none
     &:hover
       border-bottom: solid 1px
-  a[href*="//"]:not([href*="localhost:4000"]),
-  a[href*="//"]:not([href*="gferreira.github.io/fontra-docs"])
+  a[href*="//"]:not([href*="{{ site.url }}"])
     &:not(.page-link)
       &:hover
         border-bottom-width: 3px !important

--- a/index.md
+++ b/index.md
@@ -94,7 +94,7 @@ Links
 - [fontra-rcjk](http://github.com/googlefonts/fontra-rcjk)
 - [fontra-glyphs](http://github.com/googlefonts/fontra-glyphs)
 - [fontra-compile](http://github.com/googlefonts/fontra-compile)
-- [fontra-docs](http://github.com/gferreira/fontra-docs)
+- [fontra-docs](http://github.com/googlefonts/fontra-docs)
 </div>
 <div class="col-sm" markdown="1">
 ##### Downloads


### PR DESCRIPTION
Fixes #19 

As far as I was able to figure out we have to specify the `url` within _config.yml . This is then used as `{{ site.url }}`.

Here some useful links:
https://mademistakes.com/mastering-jekyll/site-url-baseurl/#what-are-url-and-baseurl
