### PR TITLE
Update documentation based on feedback

### DIFF
--- a/_reference/canvas/context-menu.md
+++ b/_reference/canvas/context-menu.md
@@ -22,9 +22,9 @@ The context menu gives access to functions specific to the current selection.
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>command</th>
-<th width='55%'>description</th>
-<th width='10%'>keys</th>
+<th width='35%'>Command</th>
+<th width='55%'>Description</th>
+<th width='10%'>Keys</th>
 </tr>
 <tr class='table-group-divider'>
 <td>Undo</td>

--- a/_reference/canvas/glyph-editor/anchors.md
+++ b/_reference/canvas/glyph-editor/anchors.md
@@ -67,8 +67,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>right click + add anchor</td>

--- a/_reference/menu.md
+++ b/_reference/menu.md
@@ -16,8 +16,8 @@ order     : 600
 
 <table class='table table-hover'>
 <tr>
-<th width='13%'>item</th>
-<th width='82%'>description</th>
+<th width='13%'>Item</th>
+<th width='82%'>Description</th>
 </tr>
 <tr>
 <td><a href='../menu/fontra'>Fontra</a></td>

--- a/_reference/menu/file.md
+++ b/_reference/menu/file.md
@@ -17,8 +17,8 @@ order     : 610
 
 <table class='table table-hover'>
 <tr>
-<th width='20%'>item</th>
-<th width='75%'>description</th>
+<th width='20%'>Item</th>
+<th width='75%'>Description</th>
 </tr>
 <tr>
 <td><a href='{{ site.url }}/reference/menu/file/export-as'>Export as</a></td>

--- a/_reference/menu/font.md
+++ b/_reference/menu/font.md
@@ -18,8 +18,8 @@ order     : 640
 <table class='table table-hover'>
 <tr>
 <th width='5%'>#</th>
-<th width='20%'>item</th>
-<th width='75%'>description</th>
+<th width='20%'>Item</th>
+<th width='75%'>Description</th>
 </tr>
 <tr>
 <td>1</td>

--- a/_reference/menu/font/cross-axis-mapping.md
+++ b/_reference/menu/font/cross-axis-mapping.md
@@ -20,7 +20,7 @@ This panel allows you to add, modify or remove cross-axis mappings (also known a
 {: .lead }
 
 <div class="alert alert-primary mt-3" role="alert" markdown='1'>
-#### Pro tips: 
+#### Pro tip: 
 {: .alert-heading}
 - Alt-key + click the arrow: show/hide all card information.
 {: .mb-0 }

--- a/_reference/menu/font/cross-axis-mapping.md
+++ b/_reference/menu/font/cross-axis-mapping.md
@@ -40,7 +40,7 @@ This panel allows you to add, modify or remove cross-axis mappings (also known a
 </tr>
 <tr>
 <td>Description</td>
-<td>„optional, string. the description of this mappings group“ (Reference: <a href='https://github.com/fonttools/fonttools/blob/main/Doc/source/designspaceLib/xml.rst#mappings-element' target="_blank">mappings-element</a>)</td>
+<td>“optional, string. the description of this mappings group” (Reference: <a href='https://github.com/fonttools/fonttools/blob/main/Doc/source/designspaceLib/xml.rst#mappings-element' target="_blank">mappings-element</a>)</td>
 </tr>
 </table>
 

--- a/_reference/menu/font/sources.md
+++ b/_reference/menu/font/sources.md
@@ -42,7 +42,7 @@ General
 </tr>
 <tr>
 <td>Italic Angle</td>
-<td>„Italic angle in counter-clockwise degrees from the vertical. Zero for upright text, negative for text that leans to the right (forward).“(Reference <a href='https://learn.microsoft.com/en-us/typography/opentype/spec/post#header' target="_blank">OT spec head table</a>)</td>
+<td>“Italic angle in counter-clockwise degrees from the vertical. Zero for upright text, negative for text that leans to the right (forward).”(Reference <a href='https://learn.microsoft.com/en-us/typography/opentype/spec/post#header' target="_blank">OT spec head table</a>)</td>
 </tr>
 </table>
 

--- a/_reference/menu/font/sources.md
+++ b/_reference/menu/font/sources.md
@@ -20,7 +20,7 @@ This is a list of all font sources of a project. Access it via *Font* -> *Source
 {: .lead }
 
 <div class="alert alert-primary mt-3" role="alert" markdown='1'>
-#### Pro tips: 
+#### Pro tip: 
 {: .alert-heading}
 - Alt-key + click the arrow: show/hide all sources information.
 {: .mb-0 }

--- a/_reference/menu/fontra.md
+++ b/_reference/menu/fontra.md
@@ -17,8 +17,8 @@ order     : 601
 
 <table class='table table-hover'>
 <tr>
-<th width='20%'>item</th>
-<th width='75%'>description</th>
+<th width='20%'>Item</th>
+<th width='75%'>Description</th>
 </tr>
 <tr>
 <td><a href='{{ site.url }}/reference/menu/fontra/shortcuts'>Shortcuts</a></td>

--- a/_reference/menu/fontra/clipboard.md
+++ b/_reference/menu/fontra/clipboard.md
@@ -17,7 +17,7 @@ order     : 605
 </nav>
 
 <div class="alert alert-primary mt-3" role="alert" markdown='1'>
-#### Pro tips: 
+#### Pro tip: 
 {: .alert-heading}
 - for example use 'glif' to copy/past from/to RoboFont
 {: .mb-0 }

--- a/_reference/menu/fontra/display-language.md
+++ b/_reference/menu/fontra/display-language.md
@@ -17,7 +17,7 @@ order     : 604
 </nav>
 
 <div class="alert alert-primary mt-3" role="alert" markdown='1'>
-#### Pro tips: 
+#### Pro tip: 
 {: .alert-heading}
 - Your language is missing? Feel free to contribute [github fontra](http://github.com/googlefonts/fontra)
 {: .mb-0 }

--- a/_reference/menu/fontra/editor-behavior.md
+++ b/_reference/menu/fontra/editor-behavior.md
@@ -21,8 +21,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>Rect-select live modifier keys</td>

--- a/_reference/menu/help.md
+++ b/_reference/menu/help.md
@@ -17,8 +17,8 @@ order     : 650
 
 <table class='table table-hover'>
 <tr>
-<th width='20%'>item</th>
-<th width='75%'>description</th>
+<th width='20%'>Item</th>
+<th width='75%'>Description</th>
 </tr>
 <tr>
 <td>Homepage</td>

--- a/_reference/menu/view.md
+++ b/_reference/menu/view.md
@@ -17,8 +17,8 @@ order     : 630
 
 <table class='table table-hover'>
 <tr>
-<th width='20%'>item</th>
-<th width='75%'>description</th>
+<th width='20%'>Item</th>
+<th width='75%'>Description</th>
 </tr>
 <tr>
 <td>Zoom</td>

--- a/_reference/menu/view/glyph-editor-appearance.md
+++ b/_reference/menu/view/glyph-editor-appearance.md
@@ -33,8 +33,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>show/hide</th>
-<th width='65%'>description</th>
+<th width='35%'>Show/Hide</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>Units-per-em grid</td>

--- a/_reference/menu/view/glyph-editor-appearance.md
+++ b/_reference/menu/view/glyph-editor-appearance.md
@@ -20,7 +20,7 @@ order     : 634
 {: .lead }
 
 <div class="alert alert-primary mt-3" role="alert" markdown='1'>
-#### Pro tips
+#### Pro tip
 {: .alert-heading}
 - use your own **[custom shortcuts](/reference/menu/fontra/shortcuts)** for the most used items
 {: .mb-0 }

--- a/_reference/navigation.md
+++ b/_reference/navigation.md
@@ -21,10 +21,10 @@ Navigation tools allow you to zoom in/out and move around in the canvas.
 
 <table class="table table-hover mb-4">
 <tr>
-<th width='10%'>icon</th>
-<th width='20%'>tool</th>
-<th width='60%'>description</th>
-<th width='10%'>short keys</th>
+<th width='10%'>Icon</th>
+<th width='20%'>Tool</th>
+<th width='60%'>Description</th>
+<th width='10%'>Short keys</th>
 </tr>
 <tr>
 <td><img height="30" src="{{ site.url }}/images/icons/plus.svg"></td>
@@ -62,8 +62,8 @@ Navigation tools allow you to zoom in/out and move around in the canvas.
 
 <table class="table table-hover mb-4">
 <tr>
-<th width='50%'>gesture</th>
-<th width='50%'>action</th>
+<th width='50%'>Gesture</th>
+<th width='50%'>Action</th>
 </tr>
 <tr>
 <td>pinch with two fingers</td>

--- a/_reference/panels.md
+++ b/_reference/panels.md
@@ -21,10 +21,10 @@ Panels provide various tools to control Fontra's workspace and the font's design
 
 <table class="table table-hover mb-4">
 <tr>
-<th>icon</th>
-<th>panel</th>
-<th>description</th>
-<th>short key</th>
+<th>Icon</th>
+<th>Panel</th>
+<th>Description</th>
+<th>Short key</th>
 </tr>
 <tr>
 <td><img height="30" src="{{ site.url }}/images/icons/texttool.svg"></td>

--- a/_reference/tools.md
+++ b/_reference/tools.md
@@ -21,10 +21,10 @@ Interactive tools allow you to edit and measure glyphs with live visual feedback
 
 <table class="table table-hover mb-4">
 <tr>
-<th>icon</th>
+<th>Icon</th>
 <th>tool</th>
-<th>description</th>
-<th>key</th>
+<th>Description</th>
+<th>Key</th>
 </tr>
 <tr>
 <td><img height="30" src="{{ site.url }}/images/icons/pointer.svg"></td>

--- a/_reference/tools/hand.md
+++ b/_reference/tools/hand.md
@@ -21,8 +21,8 @@ Click the icon in the toolbar, or use the short cut.
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>short cut</th>
-<th width='65%'>description</th>
+<th width='35%'>Short cut</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>5</td>
@@ -39,8 +39,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click + drag</td>

--- a/_reference/tools/knife.md
+++ b/_reference/tools/knife.md
@@ -21,8 +21,8 @@ Click the icon in the toolbar, or use the short cuts below.
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>short cut</th>
-<th width='65%'>description</th>
+<th width='35%'>Short cut</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>3</td>
@@ -36,8 +36,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click + drag</td>

--- a/_reference/tools/pen.md
+++ b/_reference/tools/pen.md
@@ -30,8 +30,8 @@ Click the icon in the toolbar, or use the short cut.
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>short cut</th>
-<th width='65%'>description</th>
+<th width='35%'>Short cut</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>2</td>
@@ -44,8 +44,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click</td>

--- a/_reference/tools/pointer.md
+++ b/_reference/tools/pointer.md
@@ -28,8 +28,8 @@ The *pointer* tool <img height="20" src="{{ site.url }}/images/icons/pointer.svg
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>short cut</th>
-<th width='65%'>description</th>
+<th width='35%'>Short cut</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>1</td>
@@ -43,8 +43,8 @@ Actions
 #### Glyph selection (preview mode)
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click on glyph</td>
@@ -63,8 +63,8 @@ Actions
 #### Segment selection
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click</td>
@@ -87,8 +87,8 @@ Actions
 #### Point selection
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click + drag</td>
@@ -100,8 +100,8 @@ Actions
 #### Component selection
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click + drag</td>

--- a/_reference/tools/ruler.md
+++ b/_reference/tools/ruler.md
@@ -25,8 +25,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>short cut</th>
-<th width='65%'>description</th>
+<th width='35%'>Short cut</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>4</td>

--- a/_reference/tools/shapes.md
+++ b/_reference/tools/shapes.md
@@ -21,8 +21,8 @@ Click the icon in the toolbar, or use the short cuts below.
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>short cut</th>
-<th width='65%'>description</th>
+<th width='35%'>Short cut</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>3</td>
@@ -47,8 +47,8 @@ Actions
 
 <table class='table table-hover'>
 <tr>
-<th width='35%'>action</th>
-<th width='65%'>description</th>
+<th width='35%'>Action</th>
+<th width='65%'>Description</th>
 </tr>
 <tr>
 <td>click icon + hold</td>

--- a/_reference/workspace.md
+++ b/_reference/workspace.md
@@ -19,8 +19,8 @@ order     : 100
 <table class='table table-hover'>
 <tr>
 <th width='5%'>#</th>
-<th width='13%'>item</th>
-<th width='82%'>description</th>
+<th width='13%'>Item</th>
+<th width='82%'>Description</th>
 </tr>
 <tr>
 <td>1</td>


### PR DESCRIPTION
- Drop plural s for 'Pro tip' if only one tip.
- Fix wrong german quotation marks
- Capitalize table header