### PR TITLE
Fix broken Workspace Overview link

### DIFF
--- a/_introduction/introduction.md
+++ b/_introduction/introduction.md
@@ -22,4 +22,4 @@ Quickstart
 
 - [Installing Fontra Pak on your computer]({{ site.url }}/how-tos/installation/installing-fontra-pak/)
 - [Opening a UFO or designspace file]({{ site.url }}/how-tos/opening-ufo-designspace)
-- [Workspace overview]({{ site.url }}/reference/workspace/)
+- [Workspace overview]({{ site.url }}/reference/editor-view/workspace/)


### PR DESCRIPTION
https://docs.fontra.xyz/reference/workspace/ is broken, the PR points to what seems to be the right one